### PR TITLE
Fix: The last error in a finally contexts

### DIFF
--- a/src/Context/FinallyContext.php
+++ b/src/Context/FinallyContext.php
@@ -81,4 +81,12 @@ final class FinallyContext implements FinallyContextInterface
 			throw new TransactionMustBeCommittedException();
 		}
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withError(?Throwable $error): FinallyContextInterface
+	{
+		return new self($this->connection, $this->result, $error);
+	}
 }

--- a/src/Context/FinallyContextInterface.php
+++ b/src/Context/FinallyContextInterface.php
@@ -40,4 +40,11 @@ interface FinallyContextInterface
 	 * @throws \SixtyEightPublishers\DoctrinePersistence\Exception\TransactionMustBeCommittedException
 	 */
 	public function needsEverythingCommitted(): void;
+
+	/**
+	 * @param \Throwable|NULL $error
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\FinallyContextInterface
+	 */
+	public function withError(?Throwable $error): self;
 }

--- a/src/FinallyCallbackQueueInvoker.php
+++ b/src/FinallyCallbackQueueInvoker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SixtyEightPublishers\DoctrinePersistence;
 
+use Throwable;
 use SixtyEightPublishers\DoctrinePersistence\Context\FinallyContextInterface;
 use SixtyEightPublishers\DoctrinePersistence\Exception\TransactionMustBeCommittedException;
 
@@ -24,9 +25,11 @@ class FinallyCallbackQueueInvoker
 	}
 
 	/**
+	 * @param \Throwable|NULL $lastError
+	 *
 	 * @return void
 	 */
-	public function invoke(): void
+	public function invoke(?Throwable $lastError = NULL): void
 	{
 		/**
 		 * @var callable                                                                  $callback
@@ -46,7 +49,7 @@ class FinallyCallbackQueueInvoker
 			}
 
 			if ($context->isEverythingCommitted()) {
-				$callback($context);
+				$callback($context->withError($lastError));
 				unset($this->callbacks[$key]);
 			}
 		}

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -264,12 +264,13 @@ final class Transaction implements TransactionInterface
 			$evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
 		}
 
-		$finallyContext = new FinallyContext($this->em->getConnection(), $result, NULL !== $errorContext ? $errorContext->getError() : NULL);
+		$lastError = NULL !== $errorContext ? $errorContext->getError() : NULL;
+		$finallyContext = new FinallyContext($this->em->getConnection(), $result, $lastError);
 
 		foreach ($this->finallyCallbacks as $finallyCallback) {
 			$this->finallyCallbackQueueInvoker->enqueue($finallyCallback, $finallyContext);
 		}
 
-		$this->finallyCallbackQueueInvoker->invoke();
+		$this->finallyCallbackQueueInvoker->invoke($lastError);
 	}
 }


### PR DESCRIPTION
- added method `FinallyContext::withError()`
- added an argument `$lastError` into method `FinallyCallbackQueueInvoker::invoke()`
- modified test case `FinallyCallbackQueueInvokerTestCase`