### PR TITLE
v0.2.6

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,13 +7,13 @@ $finder = PhpCsFixer\Finder::create()
 	->name('*.phpt')
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
 	->setUsingCache(FALSE)
 	->setIndent("\t")
 	->setRules([
 		'@PSR2' => TRUE,
 		'array_syntax' => ['syntax' => 'short'],
-		'trailing_comma_in_multiline_array' => true,
+		'trailing_comma_in_multiline' => TRUE,
 		'constant_case' => [
 			'case' => 'upper',
 		],

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         install:
           - travis_retry composer update --no-progress --prefer-dist
         script:
-          - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run
+          - composer run php-cs-fixer
 
     -   stage: Code Coverage
         install:

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,17 @@
 		}
 	],
 	"require": {
-		"php": "^7.3",
+		"php": "^7.4",
 		"ext-json": "*",
-		"nette/utils": "^2.4 | ^3.0",
+		"nette/utils": "^3.0",
 		"doctrine/orm": "^2.7"
 	},
 	"require-dev": {
-		"friendsofphp/php-cs-fixer": "^2.0",
+		"friendsofphp/php-cs-fixer": "^2.19",
 		"mockery/mockery": "^1.4",
-		"nette/bootstrap": "^2.4 | ^3.0",
-		"nette/di": "^2.4.16 | ^3.0.3",
+		"nette/application": "^3.0.6",
+		"nette/bootstrap": "^3.0",
+		"nette/di": "^3.0.3",
 		"nette/tester": "^2.3.4",
 		"roave/security-advisories": "dev-master"
 	},
@@ -40,6 +41,7 @@
 		"sort-packages": true
 	},
 	"scripts": {
+		"php-cs-fixer": "vendor/bin/php-cs-fixer fix -v",
 		"tests": [
 			"@tests:lowest",
 			"@tests:highest"

--- a/src/Argument/ArgumentBag.php
+++ b/src/Argument/ArgumentBag.php
@@ -9,8 +9,7 @@ use SixtyEightPublishers\DoctrinePersistence\Exception\InvalidArgumentException;
 
 class ArgumentBag implements ArgumentBagInterface
 {
-	/** @var array  */
-	private $arguments = [];
+	private array $arguments = [];
 
 	/**
 	 * @param iterable $values
@@ -38,21 +37,6 @@ class ArgumentBag implements ArgumentBagInterface
 		}
 
 		return new static($newArguments);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function add(string $name, $value): void
-	{
-		if ($this->has($name)) {
-			throw new InvalidArgumentException(sprintf(
-				'Argument with a key "%s" is already defined.',
-				$name
-			));
-		}
-
-		$this->arguments[$name] = $value;
 	}
 
 	/**

--- a/src/Argument/ArgumentBagInterface.php
+++ b/src/Argument/ArgumentBagInterface.php
@@ -19,14 +19,6 @@ interface ArgumentBagInterface extends IteratorAggregate, Countable
 
 	/**
 	 * @param string $name
-	 * @param mixed  $value
-	 *
-	 * @return void
-	 */
-	public function add(string $name, $value): void;
-
-	/**
-	 * @param string $name
 	 *
 	 * @return mixed
 	 * @throws \SixtyEightPublishers\DoctrinePersistence\Exception\InvalidArgumentException

--- a/src/Badge/BadgeBag.php
+++ b/src/Badge/BadgeBag.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Badge;
+
+class BadgeBag implements BadgeBagInterface
+{
+	private array $badges = [];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function with(BadgeInterface ...$badges): BadgeBagInterface
+	{
+		$replica = clone $this;
+
+		foreach ($badges as $badge) {
+			$replica->badges[get_class($badge)][] = $badge;
+		}
+
+		return $replica;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function last(string $badgeClassName): ?BadgeInterface
+	{
+		return isset($this->badges[$badgeClassName]) ? end($this->badges[$badgeClassName]) : NULL;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function all(?string $badgeClassName = NULL): array
+	{
+		if (NULL !== $badgeClassName) {
+			return $this->badges[$badgeClassName] ?? [];
+		}
+
+		return array_merge([], ...array_values($this->badges));
+	}
+}

--- a/src/Badge/BadgeBag.php
+++ b/src/Badge/BadgeBag.php
@@ -25,6 +25,18 @@ class BadgeBag implements BadgeBagInterface
 	/**
 	 * {@inheritDoc}
 	 */
+	public function add(BadgeInterface ...$badges): BadgeBagInterface
+	{
+		foreach ($badges as $badge) {
+			$this->badges[get_class($badge)][] = $badge;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function last(string $badgeClassName): ?BadgeInterface
 	{
 		return isset($this->badges[$badgeClassName]) ? end($this->badges[$badgeClassName]) : NULL;

--- a/src/Badge/BadgeBagInterface.php
+++ b/src/Badge/BadgeBagInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Badge;
+
+interface BadgeBagInterface
+{
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface ...$badges
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface
+	 */
+	public function with(BadgeInterface ...$badges): self;
+
+	/**
+	 * @param string $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface|null
+	 */
+	public function last(string $badgeClassName): ?BadgeInterface;
+
+	/**
+	 * @param string|NULL $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface[]
+	 */
+	public function all(?string $badgeClassName = NULL): array;
+}

--- a/src/Badge/BadgeBagInterface.php
+++ b/src/Badge/BadgeBagInterface.php
@@ -14,6 +14,13 @@ interface BadgeBagInterface
 	public function with(BadgeInterface ...$badges): self;
 
 	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface ...$badges
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface
+	 */
+	public function add(BadgeInterface ...$badges): self;
+
+	/**
 	 * @param string $badgeClassName
 	 *
 	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface|null

--- a/src/Badge/BadgeInterface.php
+++ b/src/Badge/BadgeInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Badge;
+
+interface BadgeInterface
+{
+}

--- a/src/Badge/LoggedErrorBadge.php
+++ b/src/Badge/LoggedErrorBadge.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Badge;
+
+use Throwable;
+
+final class LoggedErrorBadge implements BadgeInterface
+{
+	private Throwable $error;
+
+	/**
+	 * @param \Throwable $error
+	 */
+	public function __construct(Throwable $error)
+	{
+		$this->error = $error;
+	}
+
+	/**
+	 * @return \Throwable
+	 */
+	public function getError(): Throwable
+	{
+		return $this->error;
+	}
+}

--- a/src/Badge/NonLoggableErrorBadge.php
+++ b/src/Badge/NonLoggableErrorBadge.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Badge;
+
+use Throwable;
+
+final class NonLoggableErrorBadge implements BadgeInterface
+{
+	private Throwable $error;
+
+	/**
+	 * @param \Throwable $error
+	 */
+	public function __construct(Throwable $error)
+	{
+		$this->error = $error;
+	}
+
+	/**
+	 * @return \Throwable
+	 */
+	public function getError(): Throwable
+	{
+		return $this->error;
+	}
+}

--- a/src/Bridge/Nette/TransactionExtender/RedirectTransactionExtender.php
+++ b/src/Bridge/Nette/TransactionExtender/RedirectTransactionExtender.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Bridge\Nette\TransactionExtender;
+
+use Nette\Application\AbortException;
+use Nette\Application\ForbiddenRequestException;
+use SixtyEightPublishers\DoctrinePersistence\TransactionInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\NonLoggableErrorBadge;
+use SixtyEightPublishers\DoctrinePersistence\Context\ErrorContextInterface;
+
+final class RedirectTransactionExtender
+{
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\TransactionInterface $transaction
+	 */
+	public function __invoke(TransactionInterface $transaction): void
+	{
+		$transaction->error(static function (ErrorContextInterface $context, AbortException $e): void {
+			$context->stopPropagation();
+			$context->addBadges(new NonLoggableErrorBadge($e));
+		});
+
+		$transaction->error(static function (ErrorContextInterface $context, ForbiddenRequestException $e): void {
+			$context->stopPropagation();
+			$context->addBadges(new NonLoggableErrorBadge($e));
+		});
+	}
+}

--- a/src/Bridge/Nette/config/services.neon
+++ b/src/Bridge/Nette/config/services.neon
@@ -1,6 +1,10 @@
 services:
 	transaction_factory:
 		type: SixtyEightPublishers\DoctrinePersistence\TransactionFactoryInterface
+		factory: @extension.transaction_factory.base
+
+	transaction_factory.base:
+		type: SixtyEightPublishers\DoctrinePersistence\TransactionFactoryInterface
 		factory: SixtyEightPublishers\DoctrinePersistence\TransactionFactory(
 			@Doctrine\ORM\EntityManagerInterface,
 			@extension.finally_callback_queue_invoker,

--- a/src/Context/CommonContext.php
+++ b/src/Context/CommonContext.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface;
+use SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface;
+
+final class CommonContext implements CommonContextInterface
+{
+	private EntityManagerInterface $em;
+
+	private ArgumentBagInterface $argumentBag;
+
+	private BadgeBagInterface $badgeBag;
+
+	/**
+	 * @param \Doctrine\ORM\EntityManagerInterface                                    $em
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface $argumentBag
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface       $badgeBag
+	 */
+	public function __construct(EntityManagerInterface $em, ArgumentBagInterface $argumentBag, BadgeBagInterface $badgeBag)
+	{
+		$this->em = $em;
+		$this->argumentBag = $argumentBag;
+		$this->badgeBag = $badgeBag;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getArgumentBag(): ArgumentBagInterface
+	{
+		return $this->argumentBag;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getEntityManager(): EntityManagerInterface
+	{
+		return $this->em;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function addBadges(BadgeInterface ...$badges): void
+	{
+		$this->badgeBag = $this->badgeBag->with(...$badges);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastBadge(string $badgeClassName): ?BadgeInterface
+	{
+		return $this->badgeBag->last($badgeClassName);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getAllBadges(?string $badgeClassName = NULL): array
+	{
+		return $this->badgeBag->all($badgeClassName);
+	}
+}

--- a/src/Context/CommonContext.php
+++ b/src/Context/CommonContext.php
@@ -50,7 +50,7 @@ final class CommonContext implements CommonContextInterface
 	 */
 	public function addBadges(BadgeInterface ...$badges): void
 	{
-		$this->badgeBag = $this->badgeBag->with(...$badges);
+		$this->badgeBag->add(...$badges);
 	}
 
 	/**

--- a/src/Context/CommonContextInterface.php
+++ b/src/Context/CommonContextInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface;
+use SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface;
+
+interface CommonContextInterface
+{
+	/**
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface
+	 */
+	public function getArgumentBag(): ArgumentBagInterface;
+
+	/**
+	 * @return \Doctrine\ORM\EntityManagerInterface
+	 */
+	public function getEntityManager(): EntityManagerInterface;
+
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface ...$badges
+	 *
+	 * @return void
+	 */
+	public function addBadges(BadgeInterface ...$badges): void;
+
+	/**
+	 * @param string $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface|NULL
+	 */
+	public function getLastBadge(string $badgeClassName): ?BadgeInterface;
+
+	/**
+	 * @param string|null $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface[]
+	 */
+	public function getAllBadges(?string $badgeClassName = NULL): array;
+}

--- a/src/Context/CommonContextProxyTrait.php
+++ b/src/Context/CommonContextProxyTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+use Doctrine\ORM\EntityManagerInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface;
+use SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface;
+
+trait CommonContextProxyTrait
+{
+	protected CommonContextInterface $commonContext;
+
+	/**
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface
+	 */
+	public function getArgumentBag(): ArgumentBagInterface
+	{
+		return $this->commonContext->getArgumentBag();
+	}
+
+	/**
+	 * @return \Doctrine\ORM\EntityManagerInterface
+	 */
+	public function getEntityManager(): EntityManagerInterface
+	{
+		return $this->commonContext->getEntityManager();
+	}
+
+
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface ...$badges
+	 *
+	 * @return void
+	 */
+	public function addBadges(BadgeInterface ...$badges): void
+	{
+		$this->commonContext->addBadges(...$badges);
+	}
+
+	/**
+	 * @param string $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface|NULL
+	 */
+	public function getLastBadge(string $badgeClassName): ?BadgeInterface
+	{
+		return $this->commonContext->getLastBadge($badgeClassName);
+	}
+
+	/**
+	 * @param string|null $badgeClassName
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface[]
+	 */
+	public function getAllBadges(?string $badgeClassName = NULL): array
+	{
+		return $this->commonContext->getAllBadges($badgeClassName);
+	}
+}

--- a/src/Context/ErrorContext.php
+++ b/src/Context/ErrorContext.php
@@ -8,20 +8,21 @@ use Throwable;
 
 final class ErrorContext implements ErrorContextInterface
 {
-	/** @var \Throwable  */
-	private $error;
+	use CommonContextProxyTrait;
 
-	/** @var bool  */
-	private $propagationStopped = FALSE;
+	private Throwable $error;
 
-	/** @var bool  */
-	private $defaultBehaviourPrevented = FALSE;
+	private bool $propagationStopped = FALSE;
+
+	private bool $defaultBehaviourPrevented = FALSE;
 
 	/**
-	 * @param \Throwable $error
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Context\CommonContextInterface $commonContext
+	 * @param \Throwable                                                               $error
 	 */
-	public function __construct(Throwable $error)
+	public function __construct(CommonContextInterface $commonContext, Throwable $error)
 	{
+		$this->commonContext = $commonContext;
 		$this->error = $error;
 	}
 
@@ -36,17 +37,21 @@ final class ErrorContext implements ErrorContextInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function stopPropagation(): void
+	public function stopPropagation(): ErrorContextInterface
 	{
 		$this->propagationStopped = TRUE;
+
+		return $this;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function preventDefault(): void
+	public function preventDefault(): ErrorContextInterface
 	{
 		$this->defaultBehaviourPrevented = TRUE;
+
+		return $this;
 	}
 
 	/**

--- a/src/Context/ErrorContextInterface.php
+++ b/src/Context/ErrorContextInterface.php
@@ -6,7 +6,7 @@ namespace SixtyEightPublishers\DoctrinePersistence\Context;
 
 use Throwable;
 
-interface ErrorContextInterface
+interface ErrorContextInterface extends CommonContextInterface
 {
 	/**
 	 * @return \Throwable
@@ -16,16 +16,16 @@ interface ErrorContextInterface
 	/**
 	 * Next callbacks will be skipped
 	 *
-	 * @return void
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\ErrorContextInterface
 	 */
-	public function stopPropagation(): void;
+	public function stopPropagation(): self;
 
 	/**
 	 * Default behaviour will be prevented => an exception will not be thrown
 	 *
-	 * @return void
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\ErrorContextInterface
 	 */
-	public function preventDefault(): void;
+	public function preventDefault(): self;
 
 	/**
 	 * @return bool

--- a/src/Context/FinallyContextInterface.php
+++ b/src/Context/FinallyContextInterface.php
@@ -6,7 +6,7 @@ namespace SixtyEightPublishers\DoctrinePersistence\Context;
 
 use Throwable;
 
-interface FinallyContextInterface
+interface FinallyContextInterface extends CommonContextInterface
 {
 	/**
 	 * Last result

--- a/src/Context/SuccessContext.php
+++ b/src/Context/SuccessContext.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+use SixtyEightPublishers\DoctrinePersistence\Helper\TransactionHelper;
+
+final class SuccessContext implements SuccessContextInterface
+{
+	use CommonContextProxyTrait;
+
+	private $result;
+
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Context\CommonContextInterface $commonContext
+	 * @param mixed                                                                    $result
+	 */
+	public function __construct(CommonContextInterface $commonContext, $result)
+	{
+		$this->commonContext = $commonContext;
+		$this->result = $result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getResult()
+	{
+		return $this->result;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isEverythingCommitted(): bool
+	{
+		return TransactionHelper::isEverythingCommitted($this->getEntityManager()->getConnection());
+	}
+}

--- a/src/Context/SuccessContextInterface.php
+++ b/src/Context/SuccessContextInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+interface SuccessContextInterface extends CommonContextInterface
+{
+	/**
+	 * @return mixed
+	 */
+	public function getResult();
+
+	/**
+	 * @return bool
+	 */
+	public function isEverythingCommitted(): bool;
+}

--- a/src/Context/TransactionContext.php
+++ b/src/Context/TransactionContext.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+final class TransactionContext implements TransactionContextInterface
+{
+	use CommonContextProxyTrait;
+
+	private $previousResult;
+
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\Context\CommonContextInterface $commonContext
+	 * @param mixed                                                                    $previousResult
+	 */
+	public function __construct(CommonContextInterface $commonContext, $previousResult)
+	{
+		$this->commonContext = $commonContext;
+		$this->previousResult = $previousResult;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getPreviousResult()
+	{
+		return $this->previousResult;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function persist(object $entity): TransactionContextInterface
+	{
+		$this->getEntityManager()->persist($entity);
+
+		return $this;
+	}
+}

--- a/src/Context/TransactionContextInterface.php
+++ b/src/Context/TransactionContextInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Context;
+
+interface TransactionContextInterface extends CommonContextInterface
+{
+	/**
+	 * Returns result from a previous callback
+	 *
+	 * @return mixed
+	 */
+	public function getPreviousResult();
+
+	/**
+	 * @param object $entity
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\TransactionContextInterface
+	 */
+	public function persist(object $entity): self;
+}

--- a/src/Exception/Persistence/AbstractInvalidValueException.php
+++ b/src/Exception/Persistence/AbstractInvalidValueException.php
@@ -8,11 +8,9 @@ use Throwable;
 
 abstract class AbstractInvalidValueException extends PersistenceException
 {
-	/** @var string  */
-	protected $entityClassName;
+	protected string $entityClassName;
 
-	/** @var string  */
-	protected $columnName;
+	protected string $columnName;
 
 	/** @var mixed  */
 	protected $value;

--- a/src/Exception/Persistence/DuplicatedValueException.php
+++ b/src/Exception/Persistence/DuplicatedValueException.php
@@ -13,7 +13,7 @@ final class DuplicatedValueException extends AbstractInvalidValueException
 	 * @param string $columnName
 	 * @param $value
 	 * @param int             $code
-	 * @param \Throwable|null $previous
+	 * @param \Throwable|NULL $previous
 	 */
 	public function __construct(string $entityClassName, string $columnName, $value, int $code = 0, Throwable $previous = NULL)
 	{

--- a/src/Exception/Persistence/EntityNotFoundException.php
+++ b/src/Exception/Persistence/EntityNotFoundException.php
@@ -8,8 +8,7 @@ use Throwable;
 
 final class EntityNotFoundException extends PersistenceException
 {
-	/** @var string  */
-	private $entityClassName;
+	private string $entityClassName;
 
 	/** @var mixed  */
 	private $identifier;

--- a/src/Exception/Persistence/InvalidValueException.php
+++ b/src/Exception/Persistence/InvalidValueException.php
@@ -8,8 +8,7 @@ use Throwable;
 
 final class InvalidValueException extends AbstractInvalidValueException
 {
-	/** @var string|NULL */
-	private $reason;
+	private ?string $reason;
 
 	/** @var mixed|object|NULL */
 	private $entity;

--- a/src/Exception/Persistence/NonDeletableEntityException.php
+++ b/src/Exception/Persistence/NonDeletableEntityException.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Exception\Persistence;
+
+use Throwable;
+
+final class NonDeletableEntityException extends PersistenceException
+{
+	private object $entity;
+
+	private ?string $reason;
+
+	/**
+	 * @param object          $entity
+	 * @param string          $reason
+	 * @param int             $code
+	 * @param \Throwable|NULL $previous
+	 */
+	public function __construct(object $entity, ?string $reason = NULL, $code = 0, Throwable $previous = NULL)
+	{
+		parent::__construct(sprintf(
+			'Can\'t delete entity of type %s. %s',
+			get_class($entity),
+			$reason
+		), $code, $previous);
+
+		$this->entity = $entity;
+		$this->reason = $reason;
+	}
+
+	/**
+	 * @return object
+	 */
+	public function getEntity(): object
+	{
+		return $this->entity;
+	}
+
+	/**
+	 * @return string|NULL
+	 */
+	public function getReason(): ?string
+	{
+		return $this->reason;
+	}
+}

--- a/src/Exception/Persistence/PersistenceException.php
+++ b/src/Exception/Persistence/PersistenceException.php
@@ -9,4 +9,25 @@ use SixtyEightPublishers\DoctrinePersistence\Exception\ExceptionInterface;
 
 class PersistenceException extends Exception implements ExceptionInterface
 {
+	private array $context = [];
+
+	/**
+	 * @return array
+	 */
+	public function getContext(): array
+	{
+		return $this->context;
+	}
+
+	/**
+	 * @param array $context
+	 *
+	 * @return $this
+	 */
+	public function setContext(array $context): self
+	{
+		$this->context = $context;
+
+		return $this;
+	}
 }

--- a/src/FinallyCallbackQueueInvoker.php
+++ b/src/FinallyCallbackQueueInvoker.php
@@ -10,8 +10,7 @@ use SixtyEightPublishers\DoctrinePersistence\Exception\TransactionMustBeCommitte
 
 class FinallyCallbackQueueInvoker
 {
-	/** @var array  */
-	private $callbacks = [];
+	private array $callbacks = [];
 
 	/**
 	 * @param callable                                                                  $callback

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostFlushEventArgs;
-use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBag;
 use SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBag;
 use SixtyEightPublishers\DoctrinePersistence\Context\ErrorContext;
 use SixtyEightPublishers\DoctrinePersistence\Context\CommonContext;
@@ -145,8 +144,9 @@ final class Transaction implements TransactionInterface
 			throw RuntimeException::transactionAlreadyExecuted();
 		}
 
+		$badgeBag = $this->transactionTracker->track($this);
 		$namedArgumentBag = $this->arguments instanceof ArgumentBagInterface ? $this->arguments : new ArgumentBag($this->arguments);
-		$commonContext = new CommonContext($this->em, $namedArgumentBag, new BadgeBag());
+		$commonContext = new CommonContext($this->em, $namedArgumentBag, $badgeBag);
 
 		$typeHintedArgumentBag = new ArgumentBag([
 			EntityManagerInterface::class => $this->em,
@@ -160,7 +160,6 @@ final class Transaction implements TransactionInterface
 		$this->executed = TRUE;
 		$result = NULL;
 
-		$this->transactionTracker->track($this);
 		$this->em->getConnection()->beginTransaction();
 
 		try {

--- a/src/TransactionExtender/ErrorLogTransactionExtender.php
+++ b/src/TransactionExtender/ErrorLogTransactionExtender.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\TransactionExtender;
+
+use Psr\Log\LoggerInterface;
+use SixtyEightPublishers\DoctrinePersistence\TransactionInterface;
+use SixtyEightPublishers\DoctrinePersistence\Badge\LoggedErrorBadge;
+use SixtyEightPublishers\DoctrinePersistence\Badge\NonLoggableErrorBadge;
+use SixtyEightPublishers\DoctrinePersistence\Context\ErrorContextInterface;
+use SixtyEightPublishers\DoctrinePersistence\Context\FinallyContextInterface;
+
+final class ErrorLogTransactionExtender
+{
+	private LoggerInterface $logger;
+
+	private array $defaultNonLoggableErrorTypes = [];
+
+	/**
+	 * @param \Psr\Log\LoggerInterface $logger
+	 */
+	public function __construct(LoggerInterface $logger)
+	{
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param array $defaultNonLoggableErrorTypes
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\TransactionExtender\ErrorLogTransactionExtender
+	 */
+	public function setDefaultNonLoggableErrorTypes(array $defaultNonLoggableErrorTypes): self
+	{
+		$this->defaultNonLoggableErrorTypes = (static fn (string ...$defaultNonLoggableErrorTypes): array => $defaultNonLoggableErrorTypes)(...$defaultNonLoggableErrorTypes);
+
+		return $this;
+	}
+
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\TransactionInterface $transaction
+	 *
+	 * @return void
+	 */
+	public function __invoke(TransactionInterface $transaction): void
+	{
+		if (!empty($this->defaultNonLoggableErrorTypes)) {
+			$transaction->error(function (ErrorContextInterface $context): void {
+				$error = $context->getError();
+
+				foreach ($this->defaultNonLoggableErrorTypes as $defaultNonLoggableErrorType) {
+					if ($error instanceof $defaultNonLoggableErrorType) {
+						$context->addBadges(new NonLoggableErrorBadge($error));
+
+						return;
+					}
+				}
+			});
+		}
+
+		$transaction->finally(function (FinallyContextInterface $context): void {
+			$context->needsEverythingCommitted();
+
+			if (!$context->hasError()) {
+				return;
+			}
+
+			$error = $context->getError();
+
+			foreach ($context->getAllBadges() as $badge) {
+				if ($badge instanceof LoggedErrorBadge && $error === $badge->getError()) {
+					return;
+				}
+
+				if ($badge instanceof NonLoggableErrorBadge && $error === $badge->getError()) {
+					return;
+				}
+			}
+
+			# Dump the error into Tracy Bar if exists
+			if (function_exists('bdump')) {
+				bdump($error);
+			}
+
+			# Send the error into a logger
+			$this->logger->error((string) $error);
+			$context->addBadges(new LoggedErrorBadge($error));
+		});
+	}
+}

--- a/src/TransactionInterface.php
+++ b/src/TransactionInterface.php
@@ -48,6 +48,16 @@ interface TransactionInterface
 	 *         return $result;
 	 *     });
 	 *
+	 *     $transaction->then(function (TransactionContextInterface $context) {
+	 *         $user = $context->getPreviousResult();
+	 *         $settings = new UserSettings(...);
+	 *
+	 *         $user->setSettings($settings);
+	 *         $context->persist($settings);
+	 *
+	 *         return $user;
+	 *     });
+	 *
 	 *     $user = $transaction->run();
 	 * ```
 	 *
@@ -59,13 +69,14 @@ interface TransactionInterface
 
 	/**
 	 * This callback is called when a current transaction successfully ends.
-	 * The only parameter is a value returned from the first (initial) callback.
+	 * the first parameter is an instance of SuccessContextInterface
+	 * The second parameter is a value returned from the last callback.
 	 *
 	 * Note: everything may not be committed if the transaction is wrapped into a another transaction!
 	 *
 	 * ```php
 	 * <?php
-	 *     $transaction->success(function ($value) {});
+	 *     $transaction->success(function (SuccessContextInterface $context, $result) {});
 	 * ```
 	 *
 	 * @param callable $callback

--- a/src/TransactionTracker.php
+++ b/src/TransactionTracker.php
@@ -11,7 +11,7 @@ use SixtyEightPublishers\DoctrinePersistence\Exception\InvalidArgumentException;
 final class TransactionTracker implements TransactionTrackerInterface
 {
 	/** @var \SixtyEightPublishers\DoctrinePersistence\TransactionInterface[] */
-	private $transactions = [];
+	private array $transactions = [];
 
 	/**
 	 * {@inheritDoc}

--- a/src/TransactionTrackerInterface.php
+++ b/src/TransactionTrackerInterface.php
@@ -6,6 +6,7 @@ namespace SixtyEightPublishers\DoctrinePersistence;
 
 use Countable;
 use IteratorAggregate;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface;
 
 interface TransactionTrackerInterface extends IteratorAggregate, Countable
 {
@@ -13,8 +14,10 @@ interface TransactionTrackerInterface extends IteratorAggregate, Countable
 	 * @internal
 	 *
 	 * @param \SixtyEightPublishers\DoctrinePersistence\TransactionInterface $transaction
+	 *
+	 * @return \SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBagInterface
 	 */
-	public function track(TransactionInterface $transaction): void;
+	public function track(TransactionInterface $transaction): BadgeBagInterface;
 
 	/**
 	 * @return bool

--- a/tests/Cases/Argument/ArgumentBagTestCase.phpt
+++ b/tests/Cases/Argument/ArgumentBagTestCase.phpt
@@ -15,9 +15,6 @@ require __DIR__ . '/../../bootstrap.php';
 
 class ArgumentBagTestCase extends TestCase
 {
-	/**
-	 * @return void
-	 */
 	public function testArgumentBagConsistency(): void
 	{
 		$argumentBag = new ArgumentBag([
@@ -47,20 +44,9 @@ class ArgumentBagTestCase extends TestCase
 			$argumentBag->get('undefined');
 		}, InvalidArgumentException::class, 'Missing argument with name "undefined".');
 
-		# ::add()
-		Assert::noError(static function () use ($argumentBag) {
-			$argumentBag->add('c', 'something');
-		});
-
-		Assert::same('something', $argumentBag->get('c'));
-
-		Assert::exception(static function () use ($argumentBag) {
-			$argumentBag->add('a', 'something');
-		}, InvalidArgumentException::class, 'Argument with a key "a" is already defined.');
-
 		# Countable
-		Assert::same(6, $argumentBag->count());
-		Assert::same(6, count($argumentBag));
+		Assert::same(5, $argumentBag->count());
+		Assert::same(5, count($argumentBag));
 
 		// IteratorAggregate
 		Assert::equal([
@@ -69,7 +55,6 @@ class ArgumentBagTestCase extends TestCase
 			'foo' => $foo,
 			'bar' => NULL,
 			'baz' => $baz,
-			'c' => 'something',
 		], iterator_to_array($argumentBag));
 
 		// ::withArguments(?, FALSE)
@@ -92,7 +77,6 @@ class ArgumentBagTestCase extends TestCase
 			'foo' => $foo,
 			'bar' => NULL,
 			'baz' => $baz,
-			'c' => 'something',
 			'product' => 'Iphone',
 		], iterator_to_array($mergedArgumentBag));
 	}

--- a/tests/Cases/Badge/BadgeBagTestCase.phpt
+++ b/tests/Cases/Badge/BadgeBagTestCase.phpt
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Tests\Cases\Badge;
+
+use Exception;
+use Tester\Assert;
+use Tester\TestCase;
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeBag;
+use SixtyEightPublishers\DoctrinePersistence\Badge\LoggedErrorBadge;
+use SixtyEightPublishers\DoctrinePersistence\Tests\Fixture\DummyBadge;
+use SixtyEightPublishers\DoctrinePersistence\Badge\NonLoggableErrorBadge;
+
+require __DIR__ . '/../../bootstrap.php';
+
+class BadgeBagTestCase extends TestCase
+{
+	public function testBadgeBag(): void
+	{
+		$argumentBag = new BadgeBag();
+
+		$badge1 = new DummyBadge();
+		$badge2 = new DummyBadge();
+		$badge3 = new NonLoggableErrorBadge(new Exception('foo'));
+
+		$argumentBag = $argumentBag->with($badge1, $badge3);
+
+		Assert::equal($badge1, $argumentBag->last(DummyBadge::class));
+		Assert::equal($badge3, $argumentBag->last(NonLoggableErrorBadge::class));
+		Assert::null($argumentBag->last(LoggedErrorBadge::class));
+
+		Assert::equal([$badge1, $badge3], $argumentBag->all());
+		Assert::equal([$badge1], $argumentBag->all(DummyBadge::class));
+		Assert::equal([$badge3], $argumentBag->all(NonLoggableErrorBadge::class));
+		Assert::equal([], $argumentBag->all(LoggedErrorBadge::class));
+
+		$argumentBag = $argumentBag->with($badge2);
+
+		Assert::equal($badge2, $argumentBag->last(DummyBadge::class));
+		Assert::equal($badge3, $argumentBag->last(NonLoggableErrorBadge::class));
+		Assert::null($argumentBag->last(LoggedErrorBadge::class));
+
+		Assert::equal([$badge1, $badge2, $badge3], $argumentBag->all());
+		Assert::equal([$badge1, $badge2], $argumentBag->all(DummyBadge::class));
+		Assert::equal([$badge3], $argumentBag->all(NonLoggableErrorBadge::class));
+		Assert::equal([], $argumentBag->all(LoggedErrorBadge::class));
+	}
+}
+
+(new BadgeBagTestCase())->run();

--- a/tests/Cases/FinallyCallbackQueueInvokerTestCase.phpt
+++ b/tests/Cases/FinallyCallbackQueueInvokerTestCase.phpt
@@ -15,9 +15,6 @@ require __DIR__ . '/../bootstrap.php';
 
 class FinallyCallbackQueueInvokerTestCase extends TestCase
 {
-	/**
-	 * @return void
-	 */
 	protected function tearDown(): void
 	{
 		parent::tearDown();
@@ -25,9 +22,6 @@ class FinallyCallbackQueueInvokerTestCase extends TestCase
 		Mockery::close();
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testCallbacksInvocation(): void
 	{
 		$everythingCommitted = FALSE;
@@ -86,11 +80,6 @@ class FinallyCallbackQueueInvokerTestCase extends TestCase
 		Assert::same(1, $thirdCallbackCounter);
 	}
 
-	/**
-	 * @param bool $everythingCommitted
-	 *
-	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\FinallyContextInterface
-	 */
 	private function createContextMock(bool &$everythingCommitted): FinallyContextInterface
 	{
 		$context = Mockery::mock(FinallyContextInterface::class);

--- a/tests/Cases/Helper/CallbackInvokerTestCase.phpt
+++ b/tests/Cases/Helper/CallbackInvokerTestCase.phpt
@@ -22,9 +22,6 @@ require __DIR__ . '/../../bootstrap.php';
 
 class CallbackInvokerTestCase extends TestCase
 {
-	/**
-	 * {@inheritDoc}
-	 */
 	protected function tearDown(): void
 	{
 		parent::tearDown();
@@ -32,9 +29,6 @@ class CallbackInvokerTestCase extends TestCase
 		Mockery::close();
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeTransactionCallbackWithNamedArgumentsOnly(): void
 	{
 		[$namedArgumentBag, $typeHintedArgumentBag] = $this->createArgumentBags();
@@ -52,9 +46,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeTransactionCallbackWithTypeHintedArgumentsOnly(): void
 	{
 		[$namedArgumentBag, $typeHintedArgumentBag] = $this->createArgumentBags();
@@ -69,9 +60,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeTransactionCallbackWithCombinedArguments(): void
 	{
 		[$namedArgumentBag, $typeHintedArgumentBag] = $this->createArgumentBags();
@@ -90,9 +78,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeTransactionCallbackWithMissingButNullableArguments(): void
 	{
 		[$namedArgumentBag, $typeHintedArgumentBag] = $this->createArgumentBags();
@@ -112,9 +97,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeTransactionCallbackWithMissingArgumentsWithDefaultValues(): void
 	{
 		[$namedArgumentBag, $typeHintedArgumentBag] = $this->createArgumentBags();
@@ -131,9 +113,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldThrowExceptionWhenCallbacksContainsMissingRequiredArguments(): void
 	{
 		Assert::exception(
@@ -155,9 +134,6 @@ class CallbackInvokerTestCase extends TestCase
 		);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeErrorCallbackWithoutSpecificException(): void
 	{
 		$error = new RuntimeException();
@@ -173,9 +149,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeErrorCallbackGenericException(): void
 	{
 		$error = new RuntimeException();
@@ -202,9 +175,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::true($called);
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testShouldInvokeErrorCallbackWithSpecificException(): void
 	{
 		# 1 - RuntimeException
@@ -235,9 +205,7 @@ class CallbackInvokerTestCase extends TestCase
 
 		Assert::true($called);
 	}
-	/**
-	 * @return void
-	 */
+
 	public function testShouldNotInvokeErrorCallbackWithSpecificException(): void
 	{
 		# First
@@ -252,11 +220,6 @@ class CallbackInvokerTestCase extends TestCase
 		Assert::false($called);
 	}
 
-	/**
-	 * @param \Throwable $error
-	 *
-	 * @return \SixtyEightPublishers\DoctrinePersistence\Context\ErrorContextInterface
-	 */
 	private function createErrorContext(Throwable $error): ErrorContextInterface
 	{
 		$context = Mockery::mock(ErrorContextInterface::class);
@@ -266,9 +229,6 @@ class CallbackInvokerTestCase extends TestCase
 		return $context;
 	}
 
-	/**
-	 * @return \SixtyEightPublishers\DoctrinePersistence\Argument\ArgumentBagInterface[]
-	 */
 	private function createArgumentBags(): array
 	{
 		$namedArgumentBag = new ArgumentBag([

--- a/tests/Cases/Helper/TransactionHelperTestCase.phpt
+++ b/tests/Cases/Helper/TransactionHelperTestCase.phpt
@@ -18,9 +18,6 @@ class TransactionHelperTestCase extends TestCase
 	/** @var \Doctrine\DBAL\Connection|NULL */
 	private $connection;
 
-	/**
-	 * {@inheritDoc}
-	 */
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -31,9 +28,6 @@ class TransactionHelperTestCase extends TestCase
 		$this->connection->shouldReceive('getTransactionNestingLevel')->once()->andReturn(0);
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	protected function tearDown(): void
 	{
 		parent::tearDown();
@@ -41,18 +35,12 @@ class TransactionHelperTestCase extends TestCase
 		Mockery::close();
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testEverythingCommittedWithConnectionArgument(): void
 	{
 		Assert::false(TransactionHelper::isEverythingCommitted($this->connection));
 		Assert::true(TransactionHelper::isEverythingCommitted($this->connection));
 	}
 
-	/**
-	 * @return void
-	 */
 	public function testEverythingCommittedWithEntityManagerArgument(): void
 	{
 		$em = Mockery::mock(EntityManagerInterface::class);

--- a/tests/Fixture/DummyBadge.php
+++ b/tests/Fixture/DummyBadge.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Tests\Fixture;
+
+use SixtyEightPublishers\DoctrinePersistence\Badge\BadgeInterface;
+
+final class DummyBadge implements BadgeInterface
+{
+}

--- a/tests/Fixture/DummyTransactionExtender.php
+++ b/tests/Fixture/DummyTransactionExtender.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\DoctrinePersistence\Tests\Fixture;
+
+use SixtyEightPublishers\DoctrinePersistence\TransactionFactoryInterface;
+
+final class DummyTransactionExtender
+{
+	/**
+	 * @param \SixtyEightPublishers\DoctrinePersistence\TransactionFactoryInterface $transactionFactory
+	 *
+	 * @return void
+	 */
+	public function __invoke(TransactionFactoryInterface $transactionFactory): void
+	{
+	}
+}

--- a/tests/config/transaction_extender.neon
+++ b/tests/config/transaction_extender.neon
@@ -1,0 +1,12 @@
+services:
+	extender1:
+		type: SixtyEightPublishers\DoctrinePersistence\Tests\Fixture\DummyTransactionExtender
+		autowired: no
+		tags:
+			- 68publishers.doctrine_persistence.transaction_factory_extender
+
+	extender2:
+		type: SixtyEightPublishers\DoctrinePersistence\Tests\Fixture\DummyTransactionExtender
+		autowired: no
+		tags:
+			68publishers.doctrine_persistence.transaction_factory_extender: 10


### PR DESCRIPTION
- dropped nette 2.4 support
- dropped php 7.3 support
- added typed variables

- all transaction callbacks got contexts
- added badges
- added transaction extenders
